### PR TITLE
Project wide [when] conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,22 @@ npm i @ultimate/ngxerrors
 
 ### Setup
 
-Just add ngx-errors to your module:
+First add ngx-errors with the `forRoot()` method along with the default options to your app module:
+
+```js
+import { NgxErrorsModule } from '@ultimate/ngxerrors';
+
+@NgModule({ imports: [ 
+      NgxErrorsModule.forRoot({
+        when: ['dirty', 'touched']  //Or whatever your apps default ngxError when parameter would be
+      })
+    ] 
+})
+```
+
+The `forRoot()` default options object will allow you to set a global validation `when` to help keep your html code cleaner.  This can then be overridden per control, if needed. 
+
+Now add ngx-errors to your module:
 
 ```js
 import { NgxErrorsModule } from '@ultimate/ngxerrors';

--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -31,7 +31,7 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   @HostBinding('hidden')
   hidden: boolean = true;
 
-  rules: string[] = toArray(this.ngxErrorsService.getOptions().validators) || [];
+  rules: string[] = toArray(this.ngxErrorsService.getOptions().when) || [];
 
   errorNames: string[] = [];
 

--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -13,6 +13,7 @@ import { NgxErrorsDirective } from './ngxerrors.directive';
 import { ErrorOptions } from './ngxerrors';
 
 import { toArray } from './utils/toArray';
+import { NgxErrorsService } from './ngxerrors.service';
 
 @Directive({
   selector: '[ngxError]'
@@ -30,7 +31,7 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   @HostBinding('hidden')
   hidden: boolean = true;
 
-  rules: string[] = [];
+  rules: string[] = toArray(this.ngxErrorsService.getOptions().validators) || [];
 
   errorNames: string[] = [];
 
@@ -41,7 +42,8 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   states: Observable<string[]>;
 
   constructor(
-    @Inject(forwardRef(() => NgxErrorsDirective)) private ngxErrors: NgxErrorsDirective
+    @Inject(forwardRef(() => NgxErrorsDirective)) private ngxErrors: NgxErrorsDirective,
+    private ngxErrorsService: NgxErrorsService
   ) { }
 
   ngOnInit() {

--- a/src/ngxerrors.directive.ts
+++ b/src/ngxerrors.directive.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { ErrorDetails, ErrorOptions } from './ngxerrors';
 
 import { toArray } from './utils/toArray';
+import { NgxErrorsService } from './ngxerrors.service';
 
 @Directive({
   selector: '[ngxErrors]',
@@ -22,9 +23,9 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
 
   ready: boolean = false;
 
-  constructor(
-    private form: FormGroupDirective
-  ) { }
+  constructor(private form: FormGroupDirective,
+              private ngxErrorsService: NgxErrorsService) {
+  }
 
   get errors() {
     if (!this.ready) return;
@@ -51,7 +52,7 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
   private checkPropState(prop: string, name: string, conditions: ErrorOptions): boolean {
     if (!this.ready) return;
     const controlPropsState = (
-      !conditions || toArray(conditions).every((condition: string) => this.control[condition])
+      (!conditions && !this.ngxErrorsService.getOptions().validators) || toArray(conditions || this.ngxErrorsService.getOptions().validators).every((condition: string) => this.control[condition])
     );
     if (name.charAt(0) === '*') {
       return this.control[prop] && controlPropsState;
@@ -67,14 +68,14 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
     this.ready = true;
     if (!errors) return;
     for (const errorName in errors) {
-      this.subject.next({ control, errorName });
+      this.subject.next({control, errorName});
     }
   }
 
   ngOnChanges() {
     this.control = this.form.control.get(this.controlName);
   }
-  
+
   ngAfterViewInit() {
     setTimeout(() => {
       this.checkStatus();

--- a/src/ngxerrors.directive.ts
+++ b/src/ngxerrors.directive.ts
@@ -52,7 +52,7 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
   private checkPropState(prop: string, name: string, conditions: ErrorOptions): boolean {
     if (!this.ready) return;
     const controlPropsState = (
-      (!conditions && !this.ngxErrorsService.getOptions().validators) || toArray(conditions || this.ngxErrorsService.getOptions().validators).every((condition: string) => this.control[condition])
+      (!conditions && !this.ngxErrorsService.getOptions().when) || toArray(conditions || this.ngxErrorsService.getOptions().when).every((condition: string) => this.control[condition])
     );
     if (name.charAt(0) === '*') {
       return this.control[prop] && controlPropsState;

--- a/src/ngxerrors.module.ts
+++ b/src/ngxerrors.module.ts
@@ -1,15 +1,40 @@
-import { NgModule } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
 
 import { NgxErrorsDirective } from './ngxerrors.directive';
 import { NgxErrorDirective } from './ngxerror.directive';
+import { NgxErrorsService } from './ngxerrors.service';
 
 const dependencies = [
   NgxErrorsDirective,
   NgxErrorDirective
 ];
 
+export const OPTIONS = new InjectionToken('Token ngxErrors/default-options');
+
+export function _ngxErrorsFactory(options: any) {
+  return new NgxErrorsService(options);
+}
+
+export function provideOptions(options: any): any[] {
+  return [
+    {provide: NgxErrorsService, useFactory: _ngxErrorsFactory, deps: [OPTIONS]},
+    {provide: OPTIONS, useValue: options}
+  ];
+}
+
 @NgModule({
   declarations: [...dependencies],
   exports: [...dependencies]
 })
-export class NgxErrorsModule {}
+export class NgxErrorsModule {
+  static forRoot(options): ModuleWithProviders {
+    return {
+      ngModule: NgxErrorsModule,
+      providers: provideOptions(options)
+    }
+  }
+}
+
+
+
+

--- a/src/ngxerrors.module.ts
+++ b/src/ngxerrors.module.ts
@@ -3,6 +3,7 @@ import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
 import { NgxErrorsDirective } from './ngxerrors.directive';
 import { NgxErrorDirective } from './ngxerror.directive';
 import { NgxErrorsService } from './ngxerrors.service';
+import { NgxOptions } from './ngxerrors';
 
 const dependencies = [
   NgxErrorsDirective,
@@ -15,7 +16,7 @@ export function _ngxErrorsFactory(options: any) {
   return new NgxErrorsService(options);
 }
 
-export function provideOptions(options: any): any[] {
+export function provideOptions(options: NgxOptions): any[] {
   return [
     {provide: NgxErrorsService, useFactory: _ngxErrorsFactory, deps: [OPTIONS]},
     {provide: OPTIONS, useValue: options}
@@ -27,7 +28,7 @@ export function provideOptions(options: any): any[] {
   exports: [...dependencies]
 })
 export class NgxErrorsModule {
-  static forRoot(options): ModuleWithProviders {
+  static forRoot(options: NgxOptions = {}): ModuleWithProviders {
     return {
       ngModule: NgxErrorsModule,
       providers: provideOptions(options)

--- a/src/ngxerrors.service.ts
+++ b/src/ngxerrors.service.ts
@@ -1,10 +1,6 @@
 import { Injectable } from '@angular/core';
-import { ErrorOptions } from './ngxerrors';
+import { NgxOptions } from "./ngxerrors";
 
-
-export interface NgxOptions {
-  validators?: ErrorOptions
-}
 
 @Injectable()
 export class NgxErrorsService {

--- a/src/ngxerrors.service.ts
+++ b/src/ngxerrors.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { ErrorOptions } from './ngxerrors';
+
+
+export interface NgxOptions {
+  validators?: ErrorOptions
+}
+
+@Injectable()
+export class NgxErrorsService {
+
+  private options: NgxOptions;
+
+  constructor(options: NgxOptions) {
+    this.options = options;
+  }
+
+  getOptions() {
+    return this.options;
+  }
+}

--- a/src/ngxerrors.ts
+++ b/src/ngxerrors.ts
@@ -8,5 +8,5 @@ export interface ErrorDetails {
 }
 
 export interface NgxOptions {
-  validators?: ErrorOptions
+  when?: ErrorOptions
 }

--- a/src/ngxerrors.ts
+++ b/src/ngxerrors.ts
@@ -6,3 +6,7 @@ export interface ErrorDetails {
   control: AbstractControl,
   errorName: string
 }
+
+export interface NgxOptions {
+  validators?: ErrorOptions
+}

--- a/src/test/ngxerrors.spec.ts
+++ b/src/test/ngxerrors.spec.ts
@@ -197,7 +197,7 @@ describe('Directives: ngxErrors, ngxError, when', () => {
     expect(component.form.get('prop').hasError('minlength')).toBe(false);
     expect(component.form.get('prop').hasError('maxlength')).toBe(true);
     expect(el.query(By.css('.errorMinLength')).nativeElement.textContent).toContain('10 characters maximum');
-    
+
     expect(parse('.errorProp1').maxlength.requiredLength).toBe(10);
     expect(parse('.errorProp1').maxlength.actualLength).toBe(14);
     expect(parse('.errorProp2')).toBe(true);

--- a/src/test/ngxerrors.spec.ts
+++ b/src/test/ngxerrors.spec.ts
@@ -59,7 +59,7 @@ describe('Directives: ngxErrors, ngxError, when', () => {
     TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
-        NgxErrorsModule
+        NgxErrorsModule.forRoot()
       ],
       declarations: [
         AppComponent


### PR DESCRIPTION
**What are you adding/fixing?**
<!-- For example, you might be fixing a bug, adding a new feature or refactoring some code. Please link to the relevant issue here as well! -->
This pull request adds a `.forRoot(options)` method to the NgxErrors modules so that you can pass global application wide settings.  Currently the only option added was to have a default `when` condition that would get applied automatically without having to specify the `when` parameter or `hasErrors()` condition parameter every time.  
I have found that I almost always use `[when]=['touched']`, this new code allows me to set this initially for the entire application and never have to set it again unless I want to override it for a control.  Cleaner HTML and easier to make global changes

**Have you added tests for your changes?**
<!-- Adding tests is greatly appreciated! For all new features, tests are required. -->
I have updated the tests.

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->
I have update the documentation but please look it over and add or change if needed.

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->
Yes, this is a breaking change because you now have to add a NgxErrorsModule.forRoot() to you app module.

**Other information**
Please give it a test and let me know if you and other users find this useful.